### PR TITLE
Add VR exhibit details and agent templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A curated digital archive and immersive VR experience that chronicles the evolut
 * [Introduction](#introduction)
 * [Timeline of Communication Advancements](#timeline-of-communication-advancements)
 * [Immersive VR Experiences](#immersive-vr-experiences)
+* [Immersive VR Museum Exhibits](#immersive-vr-museum-exhibits)
 * [Project Structure](#project-structure)
 * [Installation](#installation)
 * [Usage](#usage)
@@ -49,6 +50,32 @@ Each timeline entry includes a VR module simulating the communication context:
 * **Web Browser:** Explore early web pages and hyperlink structures.
 * **VR Social Hub:** Join avatars in a shared virtual environment.
 
+## Immersive VR Museum Exhibits
+
+Our vision is to build AI-generated, cost-effective VR experiences using digitized artifacts from existing collections. Sources such as [Telecom History](https://telecomhistory.org/exhibitsmain.html) and the [Connections Museum](https://en.wikipedia.org/wiki/Connections_Museum) ensure historical accuracy.
+
+### Featured Exhibits
+
+* **1923 Panel Switch** – early automatic switching hardware.
+* **1942 No. 1 Crossbar** – reliable crossbar technology.
+* **Vintage switchboards** – manual patch-cord systems.
+
+### Asset Pipeline
+
+1. 3D scanning of artifacts.
+2. Retopology with LOD models.
+3. Spatial audio capture.
+
+### Visitor Experience Flow
+
+1. Enter a period office.
+2. Travel through a wire-tunnel.
+3. Operate an interactive switchboard.
+4. Remove the headset for an AR reveal.
+
+### Pricing Model
+
+At $10k per exhibit with ten released each year, recurring revenue could reach roughly $100k annually.
 ## Project Structure
 
 ```

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,48 @@
+# AI Agent Templates
+
+This document outlines prompt patterns for using OpenAI Codex to automate VR development tasks in this repository.
+
+## Generate VR environment code
+
+Prompt:
+```
+Generate VR environment code using the provided 3D scan data and historical references.
+
+Input folders:
+- assets/models/*
+- docs/reference-links.md
+```
+
+Output path: `scenes/` with a new scene file per exhibit.
+
+## Create interaction scripts
+
+Prompt:
+```
+Create interaction scripts that handle knob turns, patch-cord jacks and ringing logic.
+Use provided scene file and user input events.
+```
+
+Output path: `scripts/` with one script per interactive element.
+
+## Build asset pipeline scripts
+
+Prompt:
+```
+Build automation scripts for retopology and texture baking of new 3D scans.
+```
+
+Output path: `scripts/pipeline/`.
+
+## Example Codex invocations
+
+```bash
+# Generate environment code
+openai api completions.create -m codex -p "Generate VR environment code" -f assets/models/panel-switch.obj
+
+# Create interaction script
+openai api completions.create -m codex -p "Create interaction scripts" -f scenes/panel-switch.scene
+
+# Build asset pipeline
+openai api completions.create -m codex -p "Build asset pipeline scripts" -f assets/models/panel-switch.obj
+```


### PR DESCRIPTION
## Overview
- document immersive VR museum exhibit vision in README
- add agent prompt templates for Codex automation

## Testing Done
- `npm run build` *(fails: package.json missing)*
- `npm test` *(fails: package.json missing)*
- `npm run lint` *(fails: package.json missing)*
